### PR TITLE
fleetctl: {load|unload|start|stop} and get unit code cleanups

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -670,8 +670,6 @@ func lazyCreateUnits(args []string) error {
 	errchan := make(chan error)
 	var wg sync.WaitGroup
 	for _, arg := range args {
-		// TODO(jonboulle): this loop is getting too unwieldy; factor it out
-
 		arg = maybeAppendDefaultUnitType(arg)
 		name := unitNameMangle(arg)
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -745,6 +745,56 @@ func setTargetStateOfUnits(units []string, state job.JobState) ([]*schema.Unit, 
 	return triggered, nil
 }
 
+// getBlockAttempts gets the correct value of how many attempts to try
+// before giving up on an operation.
+// It returns a negative value which means try forever, if zero is
+// returned then do not make any attempt, and if a positive value is
+// returned then try up to that value
+func getBlockAttempts() int {
+	// By default we wait forever
+	var attempts int = -1
+
+	// Up to BlockAttempts
+	if sharedFlags.BlockAttempts > 0 {
+		attempts = sharedFlags.BlockAttempts
+	}
+
+	// NoBlock we do not wait
+	if sharedFlags.NoBlock {
+		attempts = 0
+	}
+
+	return attempts
+}
+
+// tryWaitForUnitStates tries to wait for units to reach the desired state.
+// It takes 5 arguments, the units to wait for, the desired state, the
+// desired JobState, how many attempts before timing out and a writer
+// interface.
+// tryWaitForUnitStates polls each of the indicated units until they
+// reach the desired state. If maxAttempts is zero, then it will not
+// wait, it will assume that all units reached their desired state.
+// If maxAttempts is negative tryWaitForUnitStates will retry forever, and
+// if it is greater than zero, it will retry up to the indicated value.
+// It returns 0 on success or 1 on errors.
+func tryWaitForUnitStates(units []string, state string, js job.JobState, maxAttempts int, out io.Writer) (ret int) {
+	// We do not wait just assume we reached the desired state
+	if maxAttempts == 0 {
+		for _, name := range units {
+			stdout("Triggered unit %s %s", name, state)
+		}
+		return
+	}
+
+	errchan := waitForUnitStates(units, js, maxAttempts, out)
+	for err := range errchan {
+		stderr("Error waiting for units: %v", err)
+		ret = 1
+	}
+
+	return
+}
+
 // waitForUnitStates polls each of the indicated units until each of their
 // states is equal to that which the caller indicates, or until the
 // polling operation times out. waitForUnitStates will retry forever, or

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -784,19 +784,19 @@ func setTargetStateOfUnits(units []string, state job.JobState) ([]*schema.Unit, 
 
 // getBlockAttempts gets the correct value of how many attempts to try
 // before giving up on an operation.
-// It returns a negative value which means try forever, if zero is
-// returned then do not make any attempt, and if a positive value is
+// It returns a negative value which means do not block, if zero is
+// returned then it means try forever, and if a positive value is
 // returned then try up to that value
 func getBlockAttempts() int {
 	// By default we wait forever
-	var attempts int = -1
+	var attempts int = 0
 
 	if sharedFlags.BlockAttempts > 0 {
 		attempts = sharedFlags.BlockAttempts
 	}
 
 	if sharedFlags.NoBlock {
-		attempts = 0
+		attempts = -1
 	}
 
 	return attempts
@@ -807,14 +807,14 @@ func getBlockAttempts() int {
 // desired JobState, how many attempts before timing out and a writer
 // interface.
 // tryWaitForUnitStates polls each of the indicated units until they
-// reach the desired state. If maxAttempts is zero, then it will not
+// reach the desired state. If maxAttempts is negative, then it will not
 // wait, it will assume that all units reached their desired state.
-// If maxAttempts is negative tryWaitForUnitStates will retry forever, and
+// If maxAttempts is zero tryWaitForUnitStates will retry forever, and
 // if it is greater than zero, it will retry up to the indicated value.
 // It returns 0 on success or 1 on errors.
 func tryWaitForUnitStates(units []string, state string, js job.JobState, maxAttempts int, out io.Writer) (ret int) {
 	// We do not wait just assume we reached the desired state
-	if maxAttempts == 0 {
+	if maxAttempts <= -1 {
 		for _, name := range units {
 			stdout("Triggered unit %s %s", name, state)
 		}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -498,14 +498,14 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 	} else {
 		// Otherwise (if the unit file does not exist), check if the
 		// name appears to be an instance unit, and if so, check for
-		// a corresponding template unit in the Registry or disk
+		// a corresponding template unit in the Registry or disk.
+		// If we found a template unit, later we create a
+		// near-identical instance unit in the Registry - same
+		// unit file as the template, but different name
 		uf, err = getUnitFileFromTemplate(file)
 		if err != nil {
 			return nil, err
 		}
-
-		// If we found a template unit, create a near-identical instance unit in
-		// the Registry - same unit file as the template, but different name
 	}
 
 	log.Debugf("Found Unit(%s)", name)
@@ -791,12 +791,10 @@ func getBlockAttempts() int {
 	// By default we wait forever
 	var attempts int = -1
 
-	// Up to BlockAttempts
 	if sharedFlags.BlockAttempts > 0 {
 		attempts = sharedFlags.BlockAttempts
 	}
 
-	// NoBlock we do not wait
 	if sharedFlags.NoBlock {
 		attempts = 0
 	}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -486,7 +486,7 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 	var uf *unit.UnitFile
 	name := unitNameMangle(file)
 
-	log.Debugf("Looking up for Unit(%s) or its corresponding template", name)
+	log.Debugf("Looking for Unit(%s) or its corresponding template", name)
 
 	// Assume that the file references a local unit file on disk and
 	// attempt to load it, if it exists

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -117,6 +117,51 @@ func TestUnitNameMangle(t *testing.T) {
 	}
 }
 
+func TestGetBlockAttempts(t *testing.T) {
+	oldNoBlock := sharedFlags.NoBlock
+	oldBlockAttempts := sharedFlags.BlockAttempts
+	sharedFlags.NoBlock = true
+	sharedFlags.BlockAttempts = 0
+
+	if n := getBlockAttempts(); n != -1 {
+		t.Errorf("got %d, want -1", n)
+	}
+
+	sharedFlags.BlockAttempts = -1
+	if n := getBlockAttempts(); n != -1 {
+		t.Errorf("got %d, want -1", n)
+	}
+
+	sharedFlags.BlockAttempts = 9999
+	if n := getBlockAttempts(); n != -1 {
+		t.Errorf("got %d, want -1", n)
+	}
+
+	sharedFlags.NoBlock = false
+	sharedFlags.BlockAttempts = 0
+	if n := getBlockAttempts(); n != 0 {
+		t.Errorf("got %d, want 0", n)
+	}
+
+	sharedFlags.BlockAttempts = -1
+	if n := getBlockAttempts(); n != 0 {
+		t.Errorf("got %d, want 0", n)
+	}
+
+	sharedFlags.BlockAttempts = 0
+	if n := getBlockAttempts(); n != 0 {
+		t.Errorf("got %d, want 0", n)
+	}
+
+	sharedFlags.BlockAttempts = 9999
+	if n := getBlockAttempts(); n != 9999 {
+		t.Errorf("got %d, want 9999", n)
+	}
+
+	sharedFlags.NoBlock = oldNoBlock
+	sharedFlags.BlockAttempts = oldBlockAttempts
+}
+
 func newUnitFile(t *testing.T, contents string) *unit.UnitFile {
 	uf, err := unit.NewUnitFile(contents)
 	if err != nil {

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -46,6 +46,8 @@ func init() {
 }
 
 func runLoadUnits(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -66,17 +68,7 @@ func runLoadUnits(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(loading, job.JobStateLoaded, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range loading {
-			stdout("Triggered unit %s load", name)
-		}
-	}
+	exit = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -46,8 +46,6 @@ func init() {
 }
 
 func runLoadUnits(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -68,7 +66,7 @@ func runLoadUnits(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -54,8 +54,6 @@ func init() {
 }
 
 func runStartUnit(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -76,7 +74,7 @@ func runStartUnit(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(starting, "start", job.JobStateLaunched, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(starting, "start", job.JobStateLaunched, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -54,6 +54,8 @@ func init() {
 }
 
 func runStartUnit(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -74,17 +76,7 @@ func runStartUnit(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(starting, job.JobStateLaunched, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range starting {
-			stdout("Triggered unit %s start", name)
-		}
-	}
+	exit = tryWaitForUnitStates(starting, "start", job.JobStateLaunched, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -52,6 +52,8 @@ func init() {
 }
 
 func runStopUnit(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -79,17 +81,7 @@ func runStopUnit(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(stopping, job.JobStateLoaded, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range stopping {
-			stdout("Triggered unit %s stop", name)
-		}
-	}
+	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -52,8 +52,6 @@ func init() {
 }
 
 func runStopUnit(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -81,7 +79,7 @@ func runStopUnit(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -36,6 +36,8 @@ func init() {
 }
 
 func runUnloadUnit(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -60,17 +62,7 @@ func runUnloadUnit(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(wait, job.JobStateInactive, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range wait {
-			stdout("Triggered unit %s unload", name)
-		}
-	}
+	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -36,8 +36,6 @@ func init() {
 }
 
 func runUnloadUnit(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -62,7 +60,7 @@ func runUnloadUnit(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, getBlockAttempts(), os.Stdout)
 
 	return
 }


### PR DESCRIPTION
This patches set aims to make the code more consistent and robust. It does not change the current behaviour just improves the code, consolidate it, more debug logs and code comments.

The main goal is to let stop, start, load and unload to share the same code base and probably avoid any corner case or bug that may related to one of these commands.

Some logic can be easily shared later when we add stop to destroy command to solve #1000

There were some TODOs in the code base that I cleaned up with the last two patches. These patches will make it easy for us to implement later #1295
