### PR TITLE
fleetctl: make the replace option work correct DesiredState

### DIFF
--- a/api/units.go
+++ b/api/units.go
@@ -112,7 +112,6 @@ func (ur *unitsResource) set(rw http.ResponseWriter, req *http.Request, item str
 			// This is a new Unit
 			newUnit = true
 		}
-		return
 	} else if eu.Name == su.Name {
 		// There is already a unit with the same name
 		// check the hashes if they do not match then we will

--- a/api/units.go
+++ b/api/units.go
@@ -76,6 +76,7 @@ func (ur *unitsResource) set(rw http.ResponseWriter, req *http.Request, item str
 	}
 
 	var su schema.Unit
+	newUnit := false
 	dec := json.NewDecoder(req.Body)
 	err := dec.Decode(&su)
 	if err != nil {
@@ -108,8 +109,22 @@ func (ur *unitsResource) set(rw http.ResponseWriter, req *http.Request, item str
 		} else if err := ValidateOptions(su.Options); err != nil {
 			sendError(rw, http.StatusBadRequest, err)
 		} else {
-			ur.create(rw, su.Name, &su)
+			// This is a new Unit
+			newUnit = true
 		}
+		return
+	} else if eu.Name == su.Name {
+		// There is already a unit with the same name
+		// check the hashes if they do not match then we will
+		// create a new unit with the same name and later
+		// the job will be update to this new unit
+		a := schema.MapSchemaUnitOptionsToUnitFile(su.Options)
+		b := schema.MapSchemaUnitOptionsToUnitFile(eu.Options)
+		newUnit = !unit.MatchUnitFiles(a, b)
+	}
+
+	if newUnit {
+		ur.create(rw, su.Name, &su)
 		return
 	}
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -556,7 +556,7 @@ func getUnitFileFromTemplate(uni *unit.UnitNameInfo, fileName string) (*unit.Uni
 	}
 
 	if tmpl != nil {
-		warnOnDifferentLocalUnit(fileName, tmpl)
+		isLocalUnitDifferent(fileName, tmpl, true, false)
 		uf = schema.MapSchemaUnitOptionsToUnitFile(tmpl.Options)
 		log.Debugf("Template Unit(%s) found in registry", uni.Template)
 	} else {
@@ -701,7 +701,7 @@ func checkUnitCreation(arg string, old *schema.Unit) (int, error) {
 		if err != nil {
 			return 1, err
 		} else if different {
-			old = unit
+			*old = *unit
 			return 0, nil
 		} else {
 			stdout("Found same Unit(%s) in Registry, nothing to do", unit.Name)
@@ -829,26 +829,6 @@ func isLocalUnitDifferent(file string, su *schema.Unit, warnIfDifferent bool, fa
 	}
 
 	return false, err
-}
-
-func warnOnDifferentLocalUnit(loc string, su *schema.Unit) {
-	suf := schema.MapSchemaUnitOptionsToUnitFile(su.Options)
-	if _, err := os.Stat(loc); !os.IsNotExist(err) {
-		luf, err := getUnitFromFile(loc)
-		if err == nil && luf.Hash() != suf.Hash() {
-			stderr("WARNING: Unit %s in registry differs from local unit file %s", su.Name, loc)
-			return
-		}
-	}
-	if uni := unit.NewUnitNameInfo(path.Base(loc)); uni != nil && uni.IsInstance() {
-		file := path.Join(path.Dir(loc), uni.Template)
-		if _, err := os.Stat(file); !os.IsNotExist(err) {
-			tmpl, err := getUnitFromFile(file)
-			if err == nil && tmpl.Hash() != suf.Hash() {
-				stderr("WARNING: Unit %s in registry differs from local template unit file %s", su.Name, uni.Template)
-			}
-		}
-	}
 }
 
 func lazyLoadUnits(args []string) ([]*schema.Unit, error) {

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -640,6 +640,14 @@ func createUnit(name string, uf *unit.UnitFile, oldUnit *schema.Unit) (*schema.U
 		return nil, fmt.Errorf("nil unit provided")
 	}
 
+	if sharedFlags.Replace {
+		log.Debugf("createUnit: destroying the existing unit before replacing it")
+		err := cAPI.DestroyUnit(name)
+		if err != nil {
+			log.Errorf("createUnit: cannot destroy unit %v", name)
+		}
+	}
+
 	if oldUnit != nil {
 		oldState = oldUnit.DesiredState
 	}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -773,16 +773,6 @@ func lazyCreateUnits(args []string) error {
 	return nil
 }
 
-// matchUnitFiles compares two unitFiles
-// Returns true if the units match, false otherwise.
-func matchUnitFiles(a *unit.UnitFile, b *unit.UnitFile) bool {
-	if a.Hash() == b.Hash() {
-		return true
-	}
-
-	return false
-}
-
 // matchLocalFileAndUnit compares a file with a Unit
 // Returns true if the contents of the file matches the unit one, false
 // otherwise; and any error ocountered
@@ -794,7 +784,7 @@ func matchLocalFileAndUnit(file string, su *schema.Unit) (bool, error) {
 	if err == nil {
 		b, err := getUnitFromFile(file)
 		if err == nil {
-			result = matchUnitFiles(a, b)
+			result = unit.MatchUnitFiles(a, b)
 		}
 	}
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -103,6 +103,7 @@ var (
 		Full          bool
 		NoLegend      bool
 		NoBlock       bool
+		Replace       bool
 		BlockAttempts int
 		Fields        string
 		SSHPort       int

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -43,6 +43,7 @@ func init() {
 	cmdLoadUnits.Flags.BoolVar(&sharedFlags.Sign, "sign", false, "DEPRECATED - this option cannot be used")
 	cmdLoadUnits.Flags.IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the jobs are loaded, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
 	cmdLoadUnits.Flags.BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the jobs have been loaded before exiting. Always the case for global units.")
+	cmdLoadUnits.Flags.BoolVar(&sharedFlags.Replace, "replace", false, "Replace the old unit and load the new one.")
 }
 
 func runLoadUnits(args []string) (exit int) {

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -51,6 +51,7 @@ func init() {
 	cmdStartUnit.Flags.BoolVar(&sharedFlags.Sign, "sign", false, "DEPRECATED - this option cannot be used")
 	cmdStartUnit.Flags.IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the units are launched, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
 	cmdStartUnit.Flags.BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the units have launched before exiting. Always the case for global units.")
+	cmdStartUnit.Flags.BoolVar(&sharedFlags.Replace, "replace", false, "Replace the old unit and start the new one.")
 }
 
 func runStartUnit(args []string) (exit int) {

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -33,6 +33,7 @@ Submit a directory of units with glob matching:
 
 func init() {
 	cmdSubmitUnit.Flags.BoolVar(&sharedFlags.Sign, "sign", false, "DEPRECATED - this option cannot be used")
+	cmdSubmitUnit.Flags.BoolVar(&sharedFlags.Replace, "replace", false, "Replace the old unit with the new one.")
 }
 
 func runSubmitUnits(args []string) (exit int) {

--- a/registry/job.go
+++ b/registry/job.go
@@ -335,7 +335,7 @@ func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
 	}
 
 	opts := &etcd.SetOptions{
-		PrevExist: etcd.PrevNoExist,
+		PrevExist: etcd.PrevIgnore,
 	}
 	key := r.prefixed(jobPrefix, u.Name, "object")
 	_, err = r.kAPI.Set(r.ctx(), key, val, opts)

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -136,6 +136,16 @@ func (u *UnitFile) Hash() Hash {
 	return Hash(sha1.Sum(u.Bytes()))
 }
 
+// MatchUnitFiles compares two unitFiles
+// Returns true if the units match, false otherwise.
+func MatchUnitFiles(a *UnitFile, b *UnitFile) bool {
+	if a.Hash() == b.Hash() {
+		return true
+	}
+
+	return false
+}
+
 // RecognizedUnitType determines whether or not the given unit name represents
 // a recognized unit type.
 func RecognizedUnitType(name string) bool {


### PR DESCRIPTION
To be able to test `fleetctl {load,submit,start} -replace foo.service`, `DesiredState` needs to be set correctly.

This PR depends on https://github.com/endocode/fleet/pull/18.

/cc @tixxdz 
